### PR TITLE
add conditional for CI checks to diff against main/master if singleton commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository contains GitHub Actions Composite Actions used for Terraform Aut
 The `mozilla/tf-actions/matrixify` action will return a list of directories that contain a versions.tf & where there has been a change in the latest git commit(s). This is useful for running a set of commands in each Terraform root directory under a given project.
 
 Inputs:
+* `default_branch`: The default branch of the repository. Defaults to main. Used for first commit on a new branch diffs.
 * `filter_file`: Files to filter for as a representation of a Terraform module or project direcotry. Defaults to "version.tf".
 * `ignore_dir`: Directories to filter out of the resulting matrix. Defaults to "ignoreme".
 * `ignore_path`: Filepaths to filter out of the resulting matrix. Defaults to "*.ignore".

--- a/matrixify/action.yml
+++ b/matrixify/action.yml
@@ -2,6 +2,10 @@ name: matrixify
 description: Enumerates changed Terraform subdirs for a matrix
 
 inputs:
+  default_branch:
+    description: "Default Repository Branch (main or master)"
+    required: false
+    default: "main"
   filter_file:
     description: "Filepaths to include"
     required: false
@@ -38,9 +42,15 @@ runs:
           echo "Diff between origin/$GITHUB_BASE_REF and $GITHUB_SHA"
         else
           # Push (per commit changes)
-          git fetch origin ${{ github.event.before }} --depth=1
-          export DIFF=$( git diff --name-only ${{ github.event.before }} $GITHUB_SHA )
-          echo "Diff between ${{ github.event.before }} and $GITHUB_SHA"
+          if [ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]; then
+            git fetch origin ${{ inputs.default_branch }} --depth=1
+            export DIFF=$( git diff --name-only origin/${{ inputs.default_branch }} $GITHUB_SHA )
+            echo "Diff between origin/${{ inputs.default_branch }} and $GITHUB_SHA"
+          else
+            git fetch origin ${{ github.event.before }} --depth=1
+            export DIFF=$( git diff --name-only ${{ github.event.before }} $GITHUB_SHA )
+            echo "Diff between ${{ github.event.before }} and $GITHUB_SHA"
+          fi
         fi
 
         echo "$DIFF"


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/OPST-180

What this PR does:
* Adds another conditional layer for the matrixify composite action for when its a push-related CI (e.g. per commit), and there is only 1 commit (so no github previous action), to generate the git-affected files by diffing the commit against main branch
* Adds a variable for matrixify composite action to define the default branch name. defaults to main, but sometimes is master.