### PR TITLE
fix bug where jq iterate fails on null when not using GCS backend

### DIFF
--- a/ci/action.yml
+++ b/ci/action.yml
@@ -111,11 +111,16 @@ runs:
           directory=$(echo ${{ inputs.tfpath }} | cut -d'/' -f1 -s)
           file_content=$(cat terraform.tf)
           json_content=$(echo $file_content | json2hcl --reverse)
-          gcs_prefix=$(echo $json_content | jq -re '.terraform[].backend[].gcs[].prefix')
+          gcs_backend=$(echo $json_content | jq -re '.terraform[].backend[] | has("gcs")')
 
-          if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
-            echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
-            exit 1 
+          if $gcs_backend ; then
+            gcs_prefix=$(echo $json_content | jq -re '.terraform[].backend[].gcs[].prefix')
+            if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
+              echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
+              exit 1 
+            fi
+          else
+            echo "INFO: ${{ inputs.tfpath }}/terraform.tf not using GCS backend."
           fi
         fi
     - name: Terraform Format

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -25,6 +25,7 @@ runs:
           sudo apt-get update
           sudo apt-get install jq
         fi
+        jq --version
     - name: Install json2hcl
       shell: bash
       run: |
@@ -111,10 +112,10 @@ runs:
           directory=$(echo ${{ inputs.tfpath }} | cut -d'/' -f1 -s)
           file_content=$(cat terraform.tf)
           json_content=$(echo $file_content | json2hcl --reverse)
-          gcs_backend=$(echo $json_content | jq -re '.terraform[].backend[] | has("gcs")')
+          gcs_backend=$(echo $json_content | jq ".terraform[].backend[] | has(\"gcs\")")
 
-          if $gcs_backend ; then
-            gcs_prefix=$(echo $json_content | jq -re '.terraform[].backend[].gcs[].prefix')
+          if $gcs_backend; then
+            gcs_prefix=$(echo $json_content | jq -re ".terraform[].backend[].gcs[].prefix")
             if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
               echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
               exit 1 


### PR DESCRIPTION
Jira: Came up in working on https://mozilla-hub.atlassian.net/browse/OPST-113

What this PR does:
* we removed a bunch of (mostly unnecessarily) conditionals when checking for a GCS backend prefix to match the project name in #1 
* however, when not using a GCS backend for state (which is not currently a requirement), the backend prefix check fails because jq throws a `jq: error (at <stdin>:1): Cannot iterate over null (null)` error (as the .gcs map is in a list in the resulting json).
* this PR adds back in 1 conditional check via jq for if a gcs backend key is present or not, and reacts accordingly

Can see this fix in action here: https://github.com/mozilla-it/websre-infra/actions

This is also blocking https://github.com/mozilla-it/websre-infra/pull/52