### PR TITLE
adding brackets

### DIFF
--- a/matrixify/action.yml
+++ b/matrixify/action.yml
@@ -82,9 +82,9 @@ runs:
             # plus any designated dirs or filepaths
             if [ -z "$rootdir" ]; then
               continue # Exclude root directory
-            elif [ "$directory" == ${{ inputs.ignore_dir }} ]; then
+            elif [[ "$directory" == ${{ inputs.ignore_dir }} ]]; then
               continue
-            elif [ "$path" == ${{ inputs.ignore_path }} ]; then
+            elif [[ "$path" == ${{ inputs.ignore_path }} ]]; then
               continue
             fi
 


### PR DESCRIPTION
So what seems to be happening here is that with the single brackets, the shell expansion happens before the test and if you have TWO subdirs that match the pattern in `inputs.ignore_dir` or `inputs.ignore_path`, then the test fails, because you're comparing a string vs a list (too many arguments)?
With double brackets, the shell expansion doesn't happen, and so the pattern matching works as expected.
The sample input here was `ignore_dir: **/example/**` with two matching paths `blahblah1/examples/example1/...` and `blahblah2/examples/example1/...`

I don't think this is a great fix, though, and perhaps we should rework how this checking is done to allow for lists or the like?