### PR TITLE
update gcs prefix check to handle env-specific subdirs

### DIFF
--- a/ci/action.yml
+++ b/ci/action.yml
@@ -109,16 +109,29 @@ runs:
         if [[ ! -f terraform.tf ]]; then
           echo "INFO: ${{ inputs.tfpath }}/terraform.tf not present."
         else
-          directory=$(echo ${{ inputs.tfpath }} | cut -d'/' -f1 -s)
+          proj_dir=$(echo ${{ inputs.tfpath }} | cut -d'/' -f1 -s)
+          tf_dir=$(echo ${{ inputs.tfpath }} | cut -d'/' -f2 -s)
+          env_dir=$(echo ${{ inputs.tfpath }} | cut -d'/' -f3 -s)
+
           file_content=$(cat terraform.tf)
           json_content=$(echo $file_content | json2hcl --reverse)
           gcs_backend=$(echo $json_content | jq ".terraform[].backend[] | has(\"gcs\")")
 
           if $gcs_backend; then
             gcs_prefix=$(echo $json_content | jq -re ".terraform[].backend[].gcs[].prefix")
-            if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
-              echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
-              exit 1 
+
+            if [ ! -z "${env_dir}" ] ; then
+              echo "INFO: ${{ inputs.tfpath }} is using Terraform environment subdirectories."
+              if [[ "$gcs_prefix" != "projects/${proj_dir}/${env_dir}" ]] ; then
+                echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
+                exit 1 
+              fi
+            else
+              echo "INFO: ${{ inputs.tfpath }} is not using Terraform environment subdirectories."
+              if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
+                echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
+                exit 1 
+              fi
             fi
           else
             echo "INFO: ${{ inputs.tfpath }}/terraform.tf not using GCS backend."

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -128,7 +128,7 @@ runs:
               fi
             else
               echo "INFO: ${{ inputs.tfpath }} is not using Terraform environment subdirectories."
-              if [[ "$gcs_prefix" != "projects/${directory}" ]] ; then
+              if [[ "$gcs_prefix" != "projects/${proj_dir}" ]] ; then
                 echo "ERROR: ${{ inputs.tfpath }}/terraform.tf has incorrect terraform.backend.gcs.prefix ${gcs_prefix}."
                 exit 1 
               fi


### PR DESCRIPTION
Jira: came up in working on https://mozilla-hub.atlassian.net/browse/OPST-343
Proposal (access-restricted): https://docs.google.com/document/d/1mu91fH5Du8jgU0RaV7HvoXYe7VeQORgCr9UE4c6yjl8/edit# 

What this PR does:
* updates the tf-actions Terraform Checks composite action step that verifies the prefix of the tf state GCP storage matches either the project name (the top level directory in a terraform monorepo) _or_ the project name plus environment (derived from optionally present subdirectory)

What this PR does not do:
* support more than 1 nested "environment" subdirectory under a TF project (top level) directory
* support workspaces - that is a future PR 