### PR TITLE
fix(ci): use jq to remove tf path suffix

### DIFF
--- a/ci/action.yml
+++ b/ci/action.yml
@@ -124,8 +124,7 @@ runs:
 
           if $gcs_backend; then
             tf_path="${{ inputs.tfpath }}"
-            # Use bash substring replacement to remove "tf/"
-            desired_gcs_path="projects/${tf_path/tf\/}"
+            desired_gcs_path=$(echo "$tf_path" | jq -r -R 'gsub("tf/$"; "")')
             gcs_prefix=$(echo $json_content | jq -re ".terraform[].backend[].gcs[].prefix")
 
             if [ "${desired_gcs_path}" != "${gcs_prefix}" ]; then


### PR DESCRIPTION
I noticed https://github.com/mozilla-it/global-platform-admin/pull/2046 failed with:

```
2024-10-12T00:00:38.1434000Z ERROR: bootstrap/tf/terraform.tf has incorrect terraform.backend.gcs.prefix projects/bootstrap. Should be projects/bootstrap/tf
```

which doesn't seem right. I noticed there was a change here last Friday so I'm guessing this is related to that.

This is kinda gross but using bash [shell parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) when trying to replace a trailing `/` didn't seem to be working, even with the escape. I read the docs but I couldn't figure out how to get the parameter substitution to work. I do know that `%` is probably more correct since we'd only want to remove the a trailing `tf/`, not the first one in the string.

Anyway  This is assuming `tf_path` ends with `tf/` and not `tf`. That might not be true. I used `jq` instead of `sed` because we were already using it elsewhere. It arguably makes little sense to do this with `jq` so I don't care how we do this as long as it works. And since this is bash in YAML there might be escape things I've messed up as well...