### PR TITLE
fix(tf-lint): Preserve JSON double quotes.

### DIFF
--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -22,7 +22,7 @@ jobs:
   matrixify:
     name: Matrixify
     outputs:
-      matrix: ${{ steps.search.outputs.matrix }}
+      matrix: ${{ inputs.ignore_dir != '' && steps.search_with_ignore.outputs.matrix || steps.search_no_ignore.outputs.matrix }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Description

Fixes matrix output handling in `tf-lint`. This change fixes a JSON parsing issue in the Terraform CI workflow caused by forwarding the matrix output through a shell step.

### Changes

* Select the matrix output directly in the job outputs using GitHub Actions expressions.
* Remove shell-based interpolation of JSON, which could corrupt quotes and produce invalid JSON.
* Ensure fromJSON() receives valid JSON when building the job matrix.

### Why
GitHub Actions expressions are evaluated before runtime, while shell steps can reinterpret JSON strings. Selecting the output at the workflow-expression level avoids this and prevents fromJSON failures.

### Related GHA issue thread
https://github.com/orgs/community/discussions/32012