### PR TITLE
feat(ci): Migrate to Opentofu v1.11.4

### DIFF
--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -16,7 +16,8 @@ on:
         default: ""
 
 env:
-  TERRAFORM_VERSION: "1.14.4"
+  # Keep this synchronized with https://github.com/mozilla/global-platform-admin/blob/main/spacelift/tf/root/locals.tf#L4
+  OPENTOFU_VERSION: "1.11.4"
 
 jobs:
   matrixify:
@@ -26,11 +27,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
       - name: Get Changed TF directories (with ignore_dir)
         if: ${{ inputs.ignore_dir != '' }}
         id: search_with_ignore
@@ -66,11 +62,12 @@ jobs:
       matrix: ${{fromJson(needs.matrixify.outputs.matrix)}}
 
     steps:
-      - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Install Opentofu
+        uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb #v2.0.0
         with:
-          terraform_wrapper: false
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
+          cache: true
+          tofu_wrapper: false
+          tofu_version: ${{ env.OPENTOFU_VERSION }}
       - id: terraform-checks
         name: Terraform Checks
         uses: mozilla/tf-actions/ci@main

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -36,17 +36,6 @@ runs:
           sudo chmod 755 /usr/local/bin/json2hcl
           json2hcl -version
         fi
-    - name: Install TFEnv
-      shell: bash
-      run: |
-        # "****** INSTALL TFENV ******"
-
-        if ! command -v "tfenv" > /dev/null; then
-          git clone https://github.com/tfutils/tfenv.git ~/.tfenv
-          sudo rm /usr/local/bin/tfenv || echo "INFO: No tfenv installed"
-          sudo rm /usr/local/bin/terraform || echo "INFO: No terraform installed"
-          sudo ln -s ~/.tfenv/bin/* /usr/local/bin > /dev/null
-        fi
     - uses: actions/cache@v4
       name: Cache plugin dir
       with:
@@ -61,17 +50,12 @@ runs:
           sudo chmod 755 /usr/local/bin/tflint
           tflint --version
         fi
-    - name: Terraform Install
-      working-directory: ${{ inputs.tfpath }}
-      shell: bash
-      run: |
-        # "****** INSTALL TERRAFORM ******"
-
-        if [ -f .terraform-version ]; then
-          tfenv install "$(cat .terraform-version)" > /dev/null
-        else
-          tfenv install 1.8.5 && tfenv use 1.8.5 > /dev/null
-        fi
+    - name: Install Opentofu
+      uses: opentofu/setup-opentofu@fc711fa910b93cba0f3fbecaafc9f42fd0c411cb #v2.0.0
+      with:
+        cache: true
+        tofu_wrapper: false
+        tofu_version: ${{ env.OPENTOFU_VERSION }}
     - name: Check README.md
       if: inputs.readme_check == 'true'
       shell: bash
@@ -147,22 +131,21 @@ runs:
       run: |
         # "****** TERRAFORM FORMAT ******"
 
-        tfenv install "$(cat .terraform-version)" > /dev/null
-        terraform fmt -recursive=true -check=true -diff=true -write=false
+        tofu fmt -recursive=true -check=true -diff=true -write=false
     - name: Terraform Init
       shell: bash
       working-directory: ${{ inputs.tfpath }}
       run: |
         # "****** TERRAFORM INIT ******"
 
-        terraform init --backend=false
+        tofu init -backend=false
     - name: Terraform Validate
       shell: bash
       working-directory: ${{ inputs.tfpath }}
       run: |
         # "****** TERRAFORM VALIDATE ******"
 
-        terraform validate
+        tofu validate
     - name: Terraform Lint
       env:
         # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting


### PR DESCRIPTION
## Description
This PR migrates the Terraform CI from Terraform v1.8.5 ❗ to Opentofu v1.11.6

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* MZCLD-2674

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for SVCSE and MZCLD, OPST, and other tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
