### PR TITLE
fix(lint): set PEM to prevent lint from failing on gh providers

### DIFF
--- a/ci/action.yml
+++ b/ci/action.yml
@@ -128,6 +128,9 @@ runs:
     - name: Terraform Format
       working-directory: ${{ inputs.tfpath }}
       shell: bash
+      env:
+        # Set PEM so the Github provider doesn't error
+        GITHUB_APP_PEM_FILE: " "
       run: |
         # "****** TERRAFORM FORMAT ******"
 

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -145,6 +145,9 @@ runs:
     - name: Terraform Validate
       shell: bash
       working-directory: ${{ inputs.tfpath }}
+      env:
+        # Set PEM so the Github provider doesn't error
+        GITHUB_APP_PEM_FILE: " "
       run: |
         # "****** TERRAFORM VALIDATE ******"
 


### PR DESCRIPTION
Sets `GITHUB_APP_PEM_FILE` to fix lint always failing on terraform that includes the Github provider.

Example: https://github.com/mozilla/global-platform-admin/actions/runs/25527361461/job/74925918374?pr=6238