### PR TITLE
fix(ci): ; then

### DIFF
--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -70,6 +70,6 @@ jobs:
           tofu_version: ${{ env.OPENTOFU_VERSION }}
       - id: terraform-checks
         name: Terraform Checks
-        uses: mozilla/tf-actions/ci@main
+        uses: mozilla/tf-actions/ci@6974df5fc32a357fd732489bbefa21528c4cb4f8
         with:
           tfpath: ${{ matrix.directory }}

--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -70,6 +70,6 @@ jobs:
           tofu_version: ${{ env.OPENTOFU_VERSION }}
       - id: terraform-checks
         name: Terraform Checks
-        uses: mozilla/tf-actions/ci@6974df5fc32a357fd732489bbefa21528c4cb4f8
+        uses: mozilla/tf-actions/ci@main
         with:
           tfpath: ${{ matrix.directory }}

--- a/ci/action.yml
+++ b/ci/action.yml
@@ -81,7 +81,7 @@ runs:
       working-directory: ${{ inputs.tfpath }}
       run: |
         # "****** CHECK terraform.required_version not set ******"
-        if grep "required_version" versions.tf 
+        if grep "required_version" versions.tf; then
           echo "ERROR: ${{ inputs.tfpath }}/versions.tf has `terraform.required_version`, which should not be set"
           exit 1
         fi


### PR DESCRIPTION
Fixes previous fix from https://github.com/mozilla/tf-actions/pull/39 to not error on a missing `; then`

---

I thought I had validated https://github.com/mozilla/tf-actions/pull/39, but there's a layer of indirection where this repo points at it's own main https://github.com/mozilla/tf-actions/blob/4554c335cda0c3d639d68891b07c163fd7e63879/.github/workflows/tf-lint.yml#L73, so in my test I was actually running the check from main (which passed, because it's broken in a way that causes it to always pass).

Now I've actually verified using https://github.com/mozilla/tf-actions/blob/4554c335cda0c3d639d68891b07c163fd7e63879/.github/workflows/tf-lint.yml#L73 & https://github.com/mozilla/webservices-infra/actions/runs/26597831365/job/78373411520?pr=11183

